### PR TITLE
Fix aggregate verbs stats

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libapache2-mod-statsd (1.0.6-1) unstable; urgency=low
+
+  * Fix aggregate verbs stats
+
+ -- Anton Winter <anton.winter@krux.com>  Sat, 21 Nov 2015 05:10:33 +0000
+
 libapache2-mod-statsd (1.0.5-2) unstable; urgency=low
 
   * New build to discern between debian versions

--- a/mod_statsd.c
+++ b/mod_statsd.c
@@ -382,7 +382,7 @@ static int request_hook(request_rec *r)
                         r->pool,
                         cfg->prefix,
                         cfg->aggregate_stat, // no dot between key & method because key
-                        r->method,           // will always end in a dot.
+                        verb,                // will always end in a dot.
                         ".",
                         apr_psprintf(r->pool, "%d", r->status),
                         cfg->suffix, // will always end in a dot.


### PR DESCRIPTION
Aggregate stats were not setting the verb to `OtherVerbs` correctly when the verb was not whitelisted.